### PR TITLE
Minor change to construct ArgSpec instance only once

### DIFF
--- a/kwargify.py
+++ b/kwargify.py
@@ -7,8 +7,9 @@ class kwargify(object):
         self._f = function
         self._defaults = {}
         self.func_defaults = tuple([])
-        self._args = inspect.getargspec(self._f).args
-        f_defaults = inspect.getargspec(self._f).defaults
+        argspec = inspect.getargspec(self._f)
+        self._args = argspec.args
+        f_defaults = argspec.defaults
         if f_defaults is not None:
             for key, value in zip(self._args[-len(f_defaults):], f_defaults):
                 self._defaults[key] = value


### PR DESCRIPTION
This decorator may be used quite a few times so it's best to reduce the work it does. This change ensures we only construct a `ArgSpec` instance once.
