### PR TITLE
Enable kwargify on class constructors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="kwargify",
-    version="2.0.1",
+    version="2.1.0",
     author="Milan Falešník",
     author_email="milan@falesnik.net",
     description="Python function kwargifier",

--- a/test_kwargify.py
+++ b/test_kwargify.py
@@ -215,3 +215,15 @@ def test_wrap_method():
     assert result_1["a"] == result_2["a"] == 1
     assert result_1["b"] == 2
     assert result_2["b"] is None
+
+
+def test_wrap_class_constructor():
+    class A(object):
+        def __init__(self, a, b=None):
+            self.a = a
+            self.b = b
+
+    cons = kwargify(A)
+    a = cons(a=1)
+    assert a.a == 1
+    assert a.b is None


### PR DESCRIPTION
Kwargify now can take also classes, in that case it pulls the __init__ for analysis but it then calls the class directly.