### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ python-kwargify
 
 [![Build Status](https://travis-ci.org/mfalesni/python-kwargify.svg?branch=master)](https://travis-ci.org/mfalesni/python-kwargify)
 [![Coverage Status](https://coveralls.io/repos/mfalesni/python-kwargify/badge.svg)](https://coveralls.io/r/mfalesni/python-kwargify)
-[![Downloads](https://pypip.in/download/kwargify/badge.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
-[![Latest version](https://pypip.in/version/kwargify/badge.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
-[![Supported Python versions](https://pypip.in/py_versions/kwargify/badge.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
-[![License](https://pypip.in/license/kwargify/badge.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
-[![Format](https://pypip.in/format/kwargify/badge.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
+[![Downloads](https://img.shields.io/pypi/dm/kwargify.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
+[![Latest version](https://img.shields.io/pypi/v/kwargify.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/kwargify.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
+[![License](https://img.shields.io/pypi/l/kwargify.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
+[![Format](https://img.shields.io/pypi/format/kwargify.svg?style=flat)](https://pypi.python.org/pypi/kwargify/)
 
 Decorator for python making it simple to convert functions with positional arguments to function taking dictionaries.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kwargify))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kwargify`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.