### PR TITLE
Update use of inspect.getargspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - "pip install -U pytest pytest-cov coveralls"
 script: "py.test -v --cov kwargify"

--- a/kwargify.py
+++ b/kwargify.py
@@ -11,7 +11,7 @@ def kwargify(a_callable):
     else:
         _method = hasattr(a_callable, "im_func") or type(a_callable).__name__ == "method"
     _defaults = {}
-    argspec = inspect.getargspec(a_callable)
+    argspec = inspect.getfullargspec(a_callable)
     if _method:
         _args = argspec.args[1:]
     else:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="kwargify",
-    version="2.2.0",
+    use_scm_version=True,
     author="Milan Falešník",
     author_email="milan@falesnik.net",
     description="Python function kwargifier",
@@ -17,6 +17,7 @@ setup(
     keywords="kwargs",
     url="https://github.com/mfalesni/python-kwargify",
     py_modules=["kwargify"],
+    setup_requires = ['setuptools', 'setuptools_scm', 'wheel'],
     install_requires=[],
     classifiers=[
         "Topic :: Utilities",


### PR DESCRIPTION
Surprise!

[WARNING] [py.warnings] ./.cfme_venv/lib64/python3.7/site-packages/kwargify.py:14: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

Bumping versions for travis to 3.5, 3.6, 3.7